### PR TITLE
Fix section 4.3 markdown image path typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1698,7 +1698,7 @@ it("Test addNewOrder, don't use such test names", () => {
 
 ### :clap: Doing It Right Example: Stryker reports, a tool for mutation testing, detects and counts the amount of code that is not tested (Mutations)
 
-![alt text](assets/bp-20-yoni-goldberg-mutation-testing.jpeg "Stryker reports, a tool for mutation testing, detects and counts the amount of code that is not tested (Mutations)
+![alt text](assets/bp-20-yoni-goldberg-mutation-testing.jpeg "Stryker reports, a tool for mutation testing, detects and counts the amount of code that is not tested (Mutations)")
 
 </details>
 


### PR DESCRIPTION
Missing `")` was causing error on image path