### PR TITLE
Suggestion: switch to fast-check in examples for property based

### DIFF
--- a/readme-zh-CN.md
+++ b/readme-zh-CN.md
@@ -441,25 +441,25 @@ it("Better: When adding new valid product, get successful confirmation", async (
 
 <br/>
 
-### :clap:  正例: 使用“mocha-testcheck”测试输入的组合
+### :clap:  正例: 使用“fast-check”测试输入的组合
 
-![](https://img.shields.io/badge/🔧%20Example%20using%20Mocha-blue.svg
+![](https://img.shields.io/badge/🔧%20Example%20using%20Jest-blue.svg
  "Examples with Jest")
 
 ```javascript
-require('mocha-testcheck').install();
-const {expect} = require('chai');
+import fc from "fast-check";
 
-describe('Product service', () => {
-  describe('Adding new', () => {
+describe("Product service", () => {
+  describe("Adding new", () => {
     //this will run 100 times with different random properties
-    check.it('Add new product with random yet valid properties, always successful',
-      gen.int, gen.string, (id, name) => {
-        expect(addNewProduct(id, name).status).to.equal('approved');
-      });
-  })
+    it("Add new product with random yet valid properties, always successful", () =>
+      fc.assert(
+        fc.property(fc.integer(), fc.string(), (id, name) => {
+          expect(addNewProduct(id, name).status).toEqual("approved");
+        })
+      ));
+  });
 });
-
 ```
 
 </details>

--- a/readme.kr.md
+++ b/readme.kr.md
@@ -419,23 +419,24 @@ it("더 나은 것: 유효한 제품이 추가된다면, 성공을 얻는다.", 
 
 <br/>
 
-### :clap:  올바른 예: “mocha-testcheck”를 사용하여 다양한 인풋 조합으로 테스트 하십시오.
+### :clap:  올바른 예: “fast-check”를 사용하여 다양한 인풋 조합으로 테스트 하십시오.
 
-![](https://img.shields.io/badge/🔧%20Example%20using%20Mocha-blue.svg
+![](https://img.shields.io/badge/🔧%20Example%20using%20Jest-blue.svg
  "Examples with Jest")
 
 ```javascript
-require('mocha-testcheck').install();
-const {expect} = require('chai');
+import fc from "fast-check";
 
-describe('Product service', () => {
-  describe('Adding new', () => {
-    //서로 다른 무작위 값으로 100회 호출됩니다. 
-    check.it('Add new product with random yet valid properties, always successful',
-      gen.int, gen.string, (id, name) => {
-        expect(addNewProduct(id, name).status).to.equal('approved');
-      });
-  })
+describe("Product service", () => {
+  describe("Adding new", () => {
+    //서로 다른 무작위 값으로 100회 호출됩니다.
+    it("Add new product with random yet valid properties, always successful", () =>
+      fc.assert(
+        fc.property(fc.integer(), fc.string(), (id, name) => {
+          expect(addNewProduct(id, name).status).toEqual("approved");
+        })
+      ));
+  });
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -451,25 +451,25 @@ it("Better: When adding new valid product, get successful confirmation", async (
 
 <br/>
 
-### :clap:  Doing It Right Example: Testing many input permutations with “mocha-testcheck”
+### :clap:  Doing It Right Example: Testing many input permutations with “fast-check”
 
-![](https://img.shields.io/badge/🔧%20Example%20using%20Mocha-blue.svg
+![](https://img.shields.io/badge/🔧%20Example%20using%20Jest-blue.svg
  "Examples with Jest")
 
 ```javascript
-require('mocha-testcheck').install();
-const {expect} = require('chai');
+import fc from "fast-check";
 
-describe('Product service', () => {
-  describe('Adding new', () => {
+describe("Product service", () => {
+  describe("Adding new", () => {
     //this will run 100 times with different random properties
-    check.it('Add new product with random yet valid properties, always successful',
-      gen.int, gen.string, (id, name) => {
-        expect(addNewProduct(id, name).status).to.equal('approved');
-      });
-  })
+    it("Add new product with random yet valid properties, always successful", () =>
+      fc.assert(
+        fc.property(fc.integer(), fc.string(), (id, name) => {
+          expect(addNewProduct(id, name).status).toEqual("approved");
+        })
+      ));
+  });
 });
-
 ```
 
 </details>


### PR DESCRIPTION
I updated the code snippets to use fast-check instead of testcheck.

As of today, it seems to be the more up-to-date library to do property based testing. It has regular releases.

In terms of downloads there are 3 main libraries and they share an even part of the market, see https://www.npmtrends.com/fast-check-vs-testcheck-vs-jsverify