### PR TITLE
Removed unneeded `.only()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -650,7 +650,7 @@ expect(errorWeExceptFor).not.to.be.null;
 ### :clap: Doing It Right Example: A human-readable expectation that could be understood easily, maybe even by QA or technical PM
 
 ```javascript
-it.only("When no product name, it throws error 400", async() => {
+it("When no product name, it throws error 400", async() => {
   await expect(addNewProduct({})).to.eventually.throw(AppError).with.property('code', "InvalidInput");
 });
 


### PR DESCRIPTION
running a single spec isn't needed in this an example case.