### PR TITLE
Add missing section number to tip 1.9 Copy code...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -536,7 +536,7 @@ it("When visiting TestJavaScript.com home page, a menu is displayed", () => {
 
 <br/><br/>
 
-## ⚪ ️Copy code, but only what's neccessary
+## ⚪ ️ 1.9 Copy code, but only what's neccessary
 
 :white_check_mark: **Do:** Include all the necessary details that affect the test result, but nothing more. As an example, consider a test that should factor 100 lines of input JSON - Pasting this in every test is tedious. Extracting it outside to transferFactory.getJSON() will leave the test vague - Without data, it's hard to correlate the test result with the cause ("why is it supposed to return 400 status?"). The classic book x-unit patterns named this pattern 'the mystery guest' - Something unseen affected our test results, we don't know what exactly. We can do better by extracting repeatable long parts outside AND mention explictly which specific details matter to the test. Going with the example above, the test can pass parameters that highlight what is important: transferFactory.getJSON({sender: undefined}). In this example, the reader should immediately infer that the empty sender field is the reason why the test should expect a validation error or any other similar adequate outcome.
 <br/>


### PR DESCRIPTION
While reading this I noticed that the number in the section heading for best practice 1.9 was missing, but the other sections all have one. 

Changes in this PR:
- Adds `1.9` to the section heading for the `Copy code...` best practice in the English edition.
  - _The other languages appear to all have `1.9` in their section headings, but I don't speak those languages so I didn't verify anything beyond searching the files for `1.9` and noting that they were in a section heading._


@goldbergyoni Thank you for the great guide! ✨✨💯